### PR TITLE
Make the inbound channel 2 times the size of the outbound channel

### DIFF
--- a/internal/net/tcp_conn.go
+++ b/internal/net/tcp_conn.go
@@ -339,7 +339,7 @@ func (c *tcpConn) setup() error {
 
 		c.logger.Debug("Successfully established a connection", c.logFields...)
 		c.mu.Lock()
-		c.inbound = make(chan codec.Link, queueSize)
+		c.inbound = make(chan codec.Link, queueSize*2)
 		c.outbound = make(chan codec.Link, queueSize)
 		c.conn = conn
 		c.rw = rw


### PR DESCRIPTION
In the pathalogical case of a client sending too many requests from a single host and not receiving responses in time from the backend (either due to the network blips or cpu overload), there's a chance that the `inbound` and the `outbound` channel both may fill up. Make the `inbound` channel at least 2 times the size of the `outbound` channel to cover 1 such failure mode.