### PR TITLE
Workflows fix with read permission

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,4 +1,6 @@
 name: Code Coverage
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   cover:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -3,6 +3,8 @@ on: [push, pull_request]
 jobs:
   golangci:
     name: lint
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,4 +1,6 @@
 name: Go Test
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   test:

--- a/.github/workflows/go-vulnerability-check.yml
+++ b/.github/workflows/go-vulnerability-check.yml
@@ -1,4 +1,6 @@
 name: Go Vulnerability Check
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   govulncheck:


### PR DESCRIPTION
Potential fix for [https://github.com/stripe/memlink/security/code-scanning/4](https://github.com/stripe/memlink/security/code-scanning/4)

To fix this issue, we should define a `permissions` block for the workflow or for the specific job—in this case, the `golangci` job. Since the job only needs to check out code and run linting, it does not require write permissions; thus, we should grant the least required privilege (`contents: read`). The `permissions` block can be placed either globally at workflow level or inside the specific job; both approaches are correct, but per the workflow shown, adding it directly to the `golangci` job is preferred for fine-grained control. This change should be made within the `.github/workflows/go-lint.yml` file, adding the permissions directly under the job definition after line 5.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
